### PR TITLE
fix(db): Make database migration more robust

### DIFF
--- a/migrations.sql
+++ b/migrations.sql
@@ -89,6 +89,22 @@ CREATE TABLE IF NOT EXISTS admin_users (
 );
 
 -- =================================================================
+-- Step 3.5: Alter existing tables idempotently
+-- This ensures that older database schemas are updated correctly.
+-- =================================================================
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'orders'
+        AND column_name = 'delivery_area'
+        AND table_schema = 'public'
+    ) THEN
+        ALTER TABLE orders ADD COLUMN delivery_area TEXT DEFAULT 'sitra' CHECK (delivery_area IN ('sitra', 'muharraq', 'other'));
+    END IF;
+END $$;
+
+-- =================================================================
 -- Step 4: Create indexes for performance
 -- =================================================================
 CREATE INDEX IF NOT EXISTS idx_products_category_id ON products(category_id);

--- a/server/routes/orders.ts
+++ b/server/routes/orders.ts
@@ -83,8 +83,8 @@ export const createOrder: RequestHandler = async (req, res) => {
     const deliveryFee = deliveryType === "delivery" ? 1.5 : 0;
     const expectedTotal = itemsTotal + deliveryFee;
 
-    // Use the total from request if provided, otherwise use calculated total
-    const finalTotal = total !== undefined ? total : expectedTotal;
+    // Always use the server-calculated total as the source of truth.
+    const finalTotal = expectedTotal;
 
     console.log("Total calculation:", {
       itemsTotal: itemsTotal.toFixed(2),


### PR DESCRIPTION
The `migrations.sql` script is updated to be more robust. It now includes an idempotent step to add the `delivery_area` column to the `orders` table if it is missing.

This ensures that databases created with an older schema version can be safely migrated to the current version by re-running the script. This also implicitly fixes an issue where the `admin_users` table might be missing.

fix(orders): Use server-calculated total for orders

The order creation logic in `server/routes/orders.ts` is updated to always use the server-calculated total, which includes the delivery fee.

Previously, the backend would trust a `total` value sent from the client, which led to orders being saved with an incorrect total that excluded the delivery fee. The backend is now the single source of truth for this calculation.