### PR TITLE
Fix: Prevent content from overflowing in cart sidebar

### DIFF
--- a/client/components/CartSidebar.tsx
+++ b/client/components/CartSidebar.tsx
@@ -90,7 +90,7 @@ export default function CartSidebar({ open, onClose }: CartSidebarProps) {
             </div>
           ) : (
             <>
-              <ScrollArea className="flex-1 px-4">
+              <ScrollArea className="flex-1 px-4 min-h-0">
                 <div className="space-y-3 py-4">
                   {items.map((item) => (
                     <div


### PR DESCRIPTION
This commit fixes a layout bug in the `CartSidebar` component where the list of items would overflow and go off-screen if it was too long.

The root cause was a common flexbox issue. The `<ScrollArea>` component, being a flex child with `flex-1`, needed to be told that its minimum height could be zero in order to shrink correctly and allow its internal scrollbar to activate.

The fix adds the `min-h-0` Tailwind class to the `<ScrollArea>` component in `CartSidebar.tsx`. This ensures the component has the correct height constraints within the flex container, allowing it to scroll properly when the content overflows.